### PR TITLE
Fix hero dot, activate Formspree, add Datenschutzerklärung

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -25,6 +25,7 @@ const year = new Date().getFullYear();
 
     <div class="footer__legal">
       <span>&copy; {year} BEWEGGRUND.</span>
+      <a href="/datenschutz" class="footer__datenschutz-link">Datenschutzerklärung</a>
     </div>
   </div>
 </footer>

--- a/src/pages/datenschutz.astro
+++ b/src/pages/datenschutz.astro
@@ -1,0 +1,172 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Datenschutzerklärung – BEWEGGRUND."
+  description="Datenschutzerklärung der Praxis BEWEGGRUND., Ildo Fisch, Triesenberg, Liechtenstein."
+>
+
+  <!-- ─── Page Header ───────────────────────── -->
+  <div class="page-header">
+    <div class="container">
+      <span class="eyebrow">BEWEGGRUND.</span>
+      <h1>Datenschutzerklärung</h1>
+      <span class="rule rule--center"></span>
+    </div>
+  </div>
+
+  <!-- ─── Content ──────────────────────────── -->
+  <section style="padding: var(--s16) 0 var(--s24);">
+    <div class="container" style="max-width: 780px;">
+
+      <div class="datenschutz-body">
+
+        <h2>1. Verantwortlicher</h2>
+        <p>
+          Verantwortlicher im Sinne der Datenschutzgesetze ist:<br /><br />
+          <strong>Ildo Fisch</strong><br />
+          Praxis BEWEGGRUND.<br />
+          Bergstrasse 3<br />
+          FL-9497 Triesenberg, Liechtenstein<br /><br />
+          Telefon: <a href="tel:+4239011112" class="text-link">00423 390 11 12</a><br />
+          E-Mail: <a href="mailto:ildo.fisch@beweggrund.li" class="text-link">ildo.fisch@beweggrund.li</a>
+        </p>
+
+        <h2>2. Grundsätze der Datenverarbeitung</h2>
+        <p>
+          Wir verarbeiten personenbezogene Daten nur im Rahmen der gesetzlichen Bestimmungen – insbesondere
+          des Datenschutzgesetzes des Fürstentums Liechtenstein (DSG) sowie der Datenschutz-Grundverordnung
+          der Europäischen Union (DSGVO), soweit anwendbar. Diese Datenschutzerklärung informiert Sie
+          darüber, welche Daten wir erfassen, wie wir sie verwenden und welche Rechte Ihnen zustehen.
+        </p>
+
+        <h2>3. Hosting und technischer Betrieb</h2>
+        <p>
+          Diese Website wird über <strong>Vercel Inc.</strong> (340 Pine Street, Suite 700, San Francisco,
+          CA 94104, USA) gehostet. Vercel verarbeitet beim Aufruf unserer Website technisch bedingt
+          Verbindungsdaten (u.&nbsp;a. IP-Adresse, aufgerufene Seite, Zeitstempel, Browser-Typ).
+          Diese Daten werden zur Auslieferung der Website benötigt und nicht dauerhaft gespeichert.
+          Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse am
+          sicheren Betrieb der Website).
+        </p>
+        <p>
+          Weitere Informationen finden Sie in der Datenschutzerklärung von Vercel:<br />
+          <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer" class="text-link">
+            vercel.com/legal/privacy-policy
+          </a>
+        </p>
+
+        <h2>4. Kontaktformular (Formspree)</h2>
+        <p>
+          Das Kontaktformular auf dieser Website wird über den Dienst <strong>Formspree</strong>
+          (Formspree Inc., 2261 Market Street #5039, San Francisco, CA 94114, USA) betrieben.
+          Wenn Sie das Formular absenden, werden die von Ihnen eingegebenen Daten (Name, Vorname,
+          E-Mail-Adresse, Nachricht) an Formspree übertragen und von dort per E-Mail an uns weitergeleitet.
+        </p>
+        <p>
+          Formspree fungiert dabei als Auftragsverarbeiter. Die Daten werden ausschliesslich zur
+          Bearbeitung Ihrer Anfrage verwendet. Nach abgeschlossener Bearbeitung werden die Daten
+          gelöscht, sofern keine gesetzlichen Aufbewahrungspflichten entgegenstehen.
+        </p>
+        <p>
+          Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;b DSGVO (Vertragsanbahnung) bzw.
+          Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse an der Beantwortung von Anfragen).
+        </p>
+        <p>
+          Weitere Informationen finden Sie in der Datenschutzerklärung von Formspree:<br />
+          <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener noreferrer" class="text-link">
+            formspree.io/legal/privacy-policy
+          </a>
+        </p>
+
+        <h2>5. Google Fonts</h2>
+        <p>
+          Diese Website verwendet <strong>Google Fonts</strong> (Google Ireland Limited, Gordon House,
+          Barrow Street, Dublin 4, Irland). Beim Laden einer Seite stellt Ihr Browser eine direkte
+          Verbindung zu den Google-Servern her, dabei wird Ihre IP-Adresse übertragen. Wir haben
+          keinen Einfluss auf die Verarbeitung dieser Daten durch Google.
+        </p>
+        <p>
+          Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse an
+          einem einheitlichen und ansprechenden Erscheinungsbild der Website).
+        </p>
+        <p>
+          Weitere Informationen finden Sie in der Datenschutzerklärung von Google:<br />
+          <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" class="text-link">
+            policies.google.com/privacy
+          </a>
+        </p>
+
+        <h2>6. Keine Analyse- oder Tracking-Tools</h2>
+        <p>
+          Wir setzen keinerlei Web-Analyse- oder Tracking-Dienste (z.&nbsp;B. Google Analytics,
+          Matomo o.&nbsp;ä.) ein. Es werden keine Cookies gesetzt, die eine persönliche
+          Identifikation ermöglichen.
+        </p>
+
+        <h2>7. Ihre Rechte</h2>
+        <p>
+          Sie haben gegenüber uns folgende Rechte hinsichtlich Ihrer personenbezogenen Daten:
+        </p>
+        <ul>
+          <li>Recht auf Auskunft (Art.&nbsp;15 DSGVO)</li>
+          <li>Recht auf Berichtigung (Art.&nbsp;16 DSGVO)</li>
+          <li>Recht auf Löschung (Art.&nbsp;17 DSGVO)</li>
+          <li>Recht auf Einschränkung der Verarbeitung (Art.&nbsp;18 DSGVO)</li>
+          <li>Recht auf Datenübertragbarkeit (Art.&nbsp;20 DSGVO)</li>
+          <li>Recht auf Widerspruch gegen die Verarbeitung (Art.&nbsp;21 DSGVO)</li>
+        </ul>
+        <p>
+          Zur Geltendmachung Ihrer Rechte wenden Sie sich bitte an:
+          <a href="mailto:ildo.fisch@beweggrund.li" class="text-link">ildo.fisch@beweggrund.li</a>
+        </p>
+        <p>
+          Ausserdem steht Ihnen ein Beschwerderecht bei der zuständigen Aufsichtsbehörde zu.
+          Für Liechtenstein ist dies die Datenschutzstelle des Fürstentums Liechtenstein
+          (DSS, Städtle 38, 9490 Vaduz, <a href="https://www.datenschutzstelle.li" target="_blank" rel="noopener noreferrer" class="text-link">www.datenschutzstelle.li</a>).
+        </p>
+
+        <h2>8. Aktualität dieser Erklärung</h2>
+        <p>
+          Diese Datenschutzerklärung ist aktuell gültig und hat den Stand April 2025.
+          Durch Weiterentwicklung unserer Website oder aufgrund geänderter gesetzlicher Vorgaben
+          kann es notwendig werden, diese Datenschutzerklärung anzupassen.
+        </p>
+
+      </div>
+    </div>
+  </section>
+
+</BaseLayout>
+
+<style>
+  .datenschutz-body h2 {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    font-weight: 400;
+    color: var(--text-dark);
+    margin-top: var(--s10);
+    margin-bottom: var(--s4);
+  }
+
+  .datenschutz-body h2:first-child {
+    margin-top: 0;
+  }
+
+  .datenschutz-body p,
+  .datenschutz-body ul {
+    font-size: var(--text-base);
+    line-height: 1.8;
+    color: var(--text-body);
+    margin-bottom: var(--s4);
+  }
+
+  .datenschutz-body ul {
+    padding-left: var(--s6);
+  }
+
+  .datenschutz-body ul li {
+    margin-bottom: var(--s2);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <div class="hero__content">
       <div class="hero__wordmark" aria-hidden="true">
-        <span class="hero__beweg">BEWEG</span><span class="hero__grund">GRUND.</span>
+        <span class="hero__beweg">BEWEG</span><span class="hero__grund">.GRUND</span>
       </div>
       <p class="hero__tagline">
         Naturheilkunde

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -59,16 +59,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             Vielen Dank für Ihre Nachricht. Ich werde mich so bald wie möglich bei Ihnen melden.
           </div>
 
-          <!--
-            Formspree-Integration:
-            1. Erstellen Sie ein kostenloses Konto auf https://formspree.io
-            2. Erstellen Sie ein neues Formular mit der E-Mail ildo.fisch@beweggrund.li
-            3. Ersetzen Sie "YOUR_FORM_ID" unten durch Ihre Formspree-Formular-ID
-          -->
           <form
             id="contact-form"
             class="form"
-            action="https://formspree.io/f/YOUR_FORM_ID"
+            action="https://formspree.io/f/myklvkne"
             method="POST"
             novalidate
           >
@@ -136,6 +130,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </p>
             </div>
 
+            <p style="margin-top: var(--s4); font-size: var(--text-xs); color: var(--text-muted);">
+              Mit dem Absenden stimmen Sie der Verarbeitung Ihrer Daten gemäss unserer
+              <a href="/datenschutz" class="text-link" style="font-size: inherit;">Datenschutzerklärung</a> zu.
+            </p>
+
           </form>
         </div>
 
@@ -153,12 +152,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     e.preventDefault();
 
     const action = form.getAttribute('action') ?? '';
-    if (action.includes('YOUR_FORM_ID')) {
-      // Dev fallback: just show success message without submitting
-      form.style.display = 'none';
-      success.style.display = 'block';
-      return;
-    }
 
     try {
       const res = await fetch(action, {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -347,6 +347,22 @@ a.text-link:hover { color: var(--green-dark); }
   font-size: var(--text-xs);
   color: #555;
   padding-top: var(--s2);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--s2);
+}
+
+.footer__datenschutz-link {
+  font-size: var(--text-xs);
+  color: #888;
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity var(--transition), color var(--transition);
+}
+.footer__datenschutz-link:hover {
+  opacity: 1;
+  color: var(--green);
 }
 
 @media (max-width: 580px) {


### PR DESCRIPTION
## Summary

- **Hero wordmark**: dot now correctly appears at the far right (`BEWEGGRUND.`) after the mirrored GRUND span — changed text from `GRUND.` to `.GRUND` so `scaleX(-1)` places the dot at the end
- **Kontakt form**: Formspree form ID `myklvkne` wired up — submissions go to ildo.fisch@beweggrund.li
- **Datenschutzerklärung** (`/datenschutz`): new page with full DSGVO-compliant privacy policy covering Vercel hosting, Formspree data processing, Google Fonts, and visitor rights
- **Footer**: small "Datenschutzerklärung" link added
- **Kontakt page**: consent note with link to Datenschutzerklärung added below form submit button

## Test plan

- [ ] Check hero on home page: wordmark reads `BEWEGGRUND.` with dot at far right
- [ ] Submit contact form — verify email arrives at ildo.fisch@beweggrund.li
- [ ] Visit `/datenschutz` — verify page renders correctly
- [ ] Click Datenschutzerklärung link in footer — navigates to `/datenschutz`
- [ ] Check mobile layout of footer and contact page

https://claude.ai/code/session_01NHfZfLTVwUR8HhvBkeMFbe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHfZfLTVwUR8HhvBkeMFbe)_